### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,7 +21,7 @@ class action_plugin_howhard extends DokuWiki_Action_Plugin
 {
 
 
-	function register(&$controller)
+	function register(Doku_Event_Handler $controller)
 	{
 		$controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'handle_toolbar', array ());
 	}

--- a/syntax.php
+++ b/syntax.php
@@ -51,7 +51,7 @@ class syntax_plugin_howhard extends DokuWiki_Syntax_Plugin
         $this->Lexer->addSpecialPattern('\{\{howhard>.*?\}\}',$mode,'plugin_howhard');
     }
 
-    public function handle($match, $state, $pos, &$handler)
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
 		switch ($state)
 		{
@@ -80,7 +80,7 @@ class syntax_plugin_howhard extends DokuWiki_Syntax_Plugin
 
     }
 
-    public function render($mode, &$renderer, $indata)
+    public function render($mode, Doku_Renderer $renderer, $indata)
     {
         list($state, $data) = $indata;
         if($mode == 'xhtml')


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.